### PR TITLE
feat: parse monorepos output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31596,7 +31596,24 @@ class SizeLimit {
     }
     parseResults(output) {
         const results = JSON.parse(output);
-        return results.reduce((current, result) => {
+        // flatten the inner array values if any
+        // From
+        // [
+        //   [{ name: 'a', size: 1 }, { name: 'b', size: 2 }],
+        //   [{ name: 'c', size: 1 }, { name: 'd', size: 2 }],
+        // ]
+        // To
+        // [{ name: 'a', size: 1 }, { name: 'b', size: 2 }, { name: 'c', size: 1 }, { name: 'd', size: 2 }]
+        let updatedResults = [];
+        results.forEach((result) => {
+            if (Array.isArray(result)) {
+                updatedResults.push(...result);
+            }
+            else {
+                updatedResults.push(result);
+            }
+        });
+        return updatedResults.reduce((current, result) => {
             let time = {};
             if (result.loading !== undefined && result.running !== undefined) {
                 const loading = +result.loading;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "size-limit-action",
+  "name": "github-action-check-size-limit",
   "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "size-limit-action",
+      "name": "github-action-check-size-limit",
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-action-check-size-limit",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "github-action-check-size-limit",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-check-size-limit",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "description": "size-limit action",
   "main": "dist/index.js",

--- a/src/SizeLimit.spec.ts
+++ b/src/SizeLimit.spec.ts
@@ -42,6 +42,47 @@ describe("SizeLimit", () => {
     });
   });
 
+  test("should parse size-limit of monorepo output", () => {
+    const limit = new SizeLimit();
+    const output = JSON.stringify([
+      [
+        {
+          name: "dist/index.js",
+          passed: true,
+          size: "110894"
+        },
+        {
+          name: "dist/new.js",
+          passed: true,
+          size: "100894"
+        }
+      ],
+      [
+        {
+          name: "dist/old.js",
+          passed: true,
+          size: "100894"
+        }
+      ],
+      []
+    ]);
+
+    expect(limit.parseResults(output)).toEqual({
+      "dist/index.js": {
+        name: "dist/index.js",
+        size: 110894
+      },
+      "dist/new.js": {
+        name: "dist/new.js",
+        size: 100894
+      },
+      "dist/old.js": {
+        name: "dist/old.js",
+        size: 100894
+      }
+    });
+  });
+
   test("should format size-limit results", () => {
     const limit = new SizeLimit();
     const base = {

--- a/src/SizeLimit.ts
+++ b/src/SizeLimit.ts
@@ -104,7 +104,24 @@ class SizeLimit {
   parseResults(output: string): { [name: string]: IResult } {
     const results = JSON.parse(output);
 
-    return results.reduce(
+    // flatten the inner array values if any
+    // From
+    // [
+    //   [{ name: 'a', size: 1 }, { name: 'b', size: 2 }],
+    //   [{ name: 'c', size: 1 }, { name: 'd', size: 2 }],
+    // ]
+    // To
+    // [{ name: 'a', size: 1 }, { name: 'b', size: 2 }, { name: 'c', size: 1 }, { name: 'd', size: 2 }]
+    let updatedResults: any[] = [];
+    results.forEach((result: { [name: string]: IResult }) => {
+      if (Array.isArray(result)) {
+        updatedResults.push(...result);
+      } else {
+        updatedResults.push(result);
+      }
+    });
+
+    return updatedResults.reduce(
       (current: { [name: string]: IResult }, result: any) => {
         let time = {};
 

--- a/src/SizeLimit.ts
+++ b/src/SizeLimit.ts
@@ -112,16 +112,16 @@ class SizeLimit {
     // ]
     // To
     // [{ name: 'a', size: 1 }, { name: 'b', size: 2 }, { name: 'c', size: 1 }, { name: 'd', size: 2 }]
-    let updatedResults: any[] = [];
+    let flattenedResults: any[] = [];
     results.forEach((result: { [name: string]: IResult }) => {
       if (Array.isArray(result)) {
-        updatedResults.push(...result);
+        flattenedResults.push(...result);
       } else {
-        updatedResults.push(result);
+        flattenedResults.push(result);
       }
     });
 
-    return updatedResults.reduce(
+    return flattenedResults.reduce(
       (current: { [name: string]: IResult }, result: any) => {
         let time = {};
 


### PR DESCRIPTION
## Description of the change

Add support for parsing size-limit output for a monorepo.

As the size-limit command is executed independently for each package in the monorepo, the output is fused into a valid JSON with additional output elements.
The terminal output may look something like this:
```
[
[{ name: 'a', size: 1 }, { name: 'b', size: 2 }],
[{ name: 'c', size: 1 }, { name: 'd', size: 2 }],
[]
]
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
