### PR TITLE
fix: process monorepo output reliably

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Run size
         uses: ./

--- a/dist/index.js
+++ b/dist/index.js
@@ -30122,7 +30122,7 @@ class Term {
     execSizeLimit(branch, skipStep, installScript, buildScript, cleanScript, windowsVerbatimArguments, directory, script, packageManager, isMonorepo, prevBranch) {
         return __awaiter(this, void 0, void 0, function* () {
             const manager = packageManager || this.getPackageManager(directory);
-            let output = isMonorepo ? '[' : '';
+            let output = '';
             if (branch) {
                 try {
                     console.log('Fetching', branch);
@@ -30155,9 +30155,6 @@ class Term {
                 listeners: {
                     stdout: (data) => {
                         output += data.toString();
-                        if (isMonorepo) {
-                            output += ', ';
-                        }
                     },
                 },
                 cwd: directory,
@@ -30169,7 +30166,7 @@ class Term {
                 });
             }
             if (isMonorepo) {
-                output += '[]\n]';
+                output = JSON.stringify(output.trim().split(/\n(?=\[)/).map((line) => JSON.parse(line)));
             }
             if (branch && prevBranch) {
                 console.log('Restoring the previous branch', prevBranch);

--- a/src/Term.ts
+++ b/src/Term.ts
@@ -44,7 +44,7 @@ class Term {
     prevBranch?: string,
   ): Promise<{ status: number; output: string }> {
     const manager = packageManager || this.getPackageManager(directory);
-    let output = isMonorepo ? '[' : '';
+    let output = '';
 
     if (branch) {
       try {
@@ -83,9 +83,6 @@ class Term {
       listeners: {
         stdout: (data: Buffer) => {
           output += data.toString();
-          if (isMonorepo) {
-            output += ', ';
-          }
         },
       },
       cwd: directory,
@@ -99,7 +96,7 @@ class Term {
     }
 
     if (isMonorepo) {
-      output += '[]\n]';
+      output = JSON.stringify(output.trim().split(/\n(?=\[)/).map((line) => JSON.parse(line)));
     }
 
     if (branch && prevBranch) {


### PR DESCRIPTION
## Description of the change

When using this action with Nx (monorepo tooling) and the output is a cached response, the previous manipulation to convert it into a proper JSON string does not work.
Now, I've used the proper technique to parse and covert the output.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
